### PR TITLE
Fix Lambda error

### DIFF
--- a/credking.py
+++ b/credking.py
@@ -337,7 +337,7 @@ def create_lambda(access_key, secret_access_key, zip_path, region_idx):
 				MemorySize=128,
 				Publish=True,
 				Role=role_name,
-				Runtime='python3.6',
+				Runtime='python3.9',
 				Timeout=8,
 				VpcConfig={
 				},


### PR DESCRIPTION
Error:
```sh
[2023-02-14 15:03:41] Error creating lambda using build/gmail_XXXXXXX.zip in us-east-2: An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.
```